### PR TITLE
Conformance

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [4.x, 6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 17.x]
+        node-version: [4.x, 6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 18.x]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 coverage/
 node_modules/
+.nyc_output/

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@
 coverage/
 node_modules/
 test.js
+.nyc_output/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 Joe Hildebrand
+Copyright (c) 2022 Joe Hildebrand
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cto.af/textdecoder",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Quick wrapper that finds TextDecoder or polyfills a bad implementation",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   "author": "Joe Hildebrand <joe-github@cursive.net>",
   "license": "MIT",
   "devDependencies": {
-    "@cto.af/eslint-config": "^0.0.12",
-    "eslint": "^8.2.0",
-    "eslint-plugin-ava": "^13.1.0",
-    "eslint-plugin-jsdoc": "^37.0.3",
+    "@cto.af/eslint-config": "^0.1.3",
+    "eslint": "^8.18.0",
+    "eslint-plugin-ava": "^13.2.0",
+    "eslint-plugin-jsdoc": "^39.3.2",
     "eslint-plugin-node": "^11.1.0"
   },
   "engines": {

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,0 +1,192 @@
+/* eslint-disable prefer-destructuring */
+'use strict'
+
+const REPLACEMENT = '\ufffd'
+const BYTES = {
+  // 0b00_000 - 0b01_111: ASCII
+  0: 0,
+  1: 0,
+  2: 0,
+  3: 0,
+  4: 0,
+  5: 0,
+  6: 0,
+  7: 0,
+  8: 0,
+  9: 0,
+  10: 0,
+  11: 0,
+  12: 0,
+  13: 0,
+  14: 0,
+  15: 0,
+
+  // 0b10_000 - 0b10_111: Continuation
+  16: -1,
+  17: -1,
+  18: -1,
+  19: -1,
+  20: -1,
+  21: -1,
+  22: -1,
+  23: -1,
+
+  // 0b110_00 - 0b110_11: Two bytes
+  24: 1,
+  25: 1,
+  26: 1,
+  27: 1,
+
+  // 0b1110_0 - 0b1110_1: Three bytes
+  28: 2,
+  29: 2,
+
+  // 0b11110: Four bytes
+  30: 3,
+
+  // 0b11111: Invalid
+  31: -2,
+}
+
+const ERR_MSG = '[ERR_ENCODING_INVALID_ENCODED_DATA]: ' +
+'The encoded data was not valid for encoding utf-8'
+
+function utf8Decode(buf, fatal, state) {
+  if (!state) {
+    state = {cur: 0, left: 0}
+  }
+  let res = ''
+  for (const b of buf) {
+    const bytes = BYTES[(b & 0xf8) >> 3]
+    switch (bytes) {
+      case -2:
+        // Top 5 bits all set
+        state.cur = 0
+        state.left = 0
+        if (fatal) {
+          const err = new TypeError(ERR_MSG)
+          err.code = 'ERR_ENCODING_INVALID_ENCODED_DATA'
+          err.errno = 12
+          throw err
+        } else {
+          res += REPLACEMENT
+        }
+        break
+      case -1:
+        state.left--
+        if (state.left < 0) {
+          // Too many continuation bytes
+          state.cur = 0
+          state.left = 0
+          if (fatal) {
+            const err = new TypeError(ERR_MSG)
+            err.code = 'ERR_ENCODING_INVALID_ENCODED_DATA'
+            err.errno = 12
+            throw err
+          } else {
+            res += REPLACEMENT
+          }
+        } else {
+          state.cur = (state.cur << 6) | (b & 0x3f)
+          if (state.left === 0) {
+            res += String.fromCodePoint(state.cur)
+            state.cur = 0
+          }
+        }
+        break
+      case 0: // One ASCII7 byte
+        if ((state.cur !== 0) || (state.left !== 0)) {
+          // Not enough continuation bytes
+          state.cur = 0
+          state.left = 0
+          if (fatal) {
+            const err = new TypeError(ERR_MSG)
+            err.code = 'ERR_ENCODING_INVALID_ENCODED_DATA'
+            err.errno = 12
+            throw err
+          } else {
+            res += REPLACEMENT
+          }
+        }
+        res += String.fromCharCode(b)
+        break
+      default:
+        if ((state.cur !== 0) || (state.left !== 0)) {
+          // Not enough continuation bytes
+          state.cur = 0
+          state.left = 0
+          if (fatal) {
+            const err = new TypeError(ERR_MSG)
+            err.code = 'ERR_ENCODING_INVALID_ENCODED_DATA'
+            err.errno = 12
+            throw err
+          } else {
+            res += REPLACEMENT
+          }
+        }
+        state.left = bytes
+        state.cur = b & (0xff >> (bytes + 2))
+        break
+    }
+  }
+  return [res, state]
+}
+
+class TextDecoderPolyfill {
+  constructor(utfLabel, options) {
+    this.utfLabel = (utfLabel || 'utf-8').toLowerCase()
+    if ((this.utfLabel !== 'utf-8') && (this.utfLabel !== 'utf8')) {
+      const err = new RangeError('The "' + utfLabel + '" encoding is not supported')
+      err.code = 'ERR_ENCODING_NOT_SUPPORTED'
+      throw err
+    }
+    options = options || {}
+    this.fatal = Boolean(options.fatal)
+    this.ignoreBOM = Boolean(options.ignoreBOM)
+    this.state = null
+  }
+
+  decode(input, options) {
+    if (!(input instanceof Uint8Array)) {
+      if (input instanceof ArrayBuffer) {
+        input = new Uint8Array(input)
+      } else if (ArrayBuffer.isView(input)) {
+        input = new Uint8Array(input.buffer, input.byteOffset, input.byteLength)
+      } else {
+        const typ = typeof input
+        const err = new TypeError('The "input" argument must be an instance of ArrayBuffer or ArrayBufferView. Received type ' + typ)
+        err.code = 'ERR_INVALID_ARG_TYPE'
+        throw err
+      }
+    }
+    const str_state = utf8Decode(input, this.fatal, this.state)
+    let str = str_state[0]
+    const state = str_state[1]
+    if (options && options.stream) {
+      this.state = state
+    } else {
+      this.state = null
+      if (state.left !== 0) {
+        // Truncated
+        if (this.fatal) {
+          const err = new TypeError(ERR_MSG)
+          err.code = 'ERR_ENCODING_INVALID_ENCODED_DATA'
+          err.errno = 11
+          throw err
+        } else {
+          str += REPLACEMENT
+        }
+      }
+    }
+
+    if (!this.ignoreBOM) {
+      // U+FEFF: BYTE ORDER MARK
+      if (str.codePointAt(0) === 0xFEFF) {
+        return str.slice(1)
+      }
+    }
+    return str
+  }
+}
+
+module.exports = TextDecoderPolyfill

--- a/test.js
+++ b/test.js
@@ -1,14 +1,25 @@
 'use strict'
 
 const assert = require('assert')
-
 const TxtD = require('./')
+const Polyfill = require('./polyfill.js')
 
 function test(TD) {
+  assert.throws(() => new TD('foo'))
+
   const td = new TD('utf8', {fatal: true, ignoreBOM: true})
   assert.equal(td.decode(Buffer.from('E282AC', 'hex')), '€')
   assert.equal(td.decode(Buffer.from('EFBBBFE282AC', 'hex')), '\ufeff€')
   assert.throws(() => td.decode(Buffer.from('E1A0C0', 'hex')))
+  assert.throws(() => td.decode('foo'))
+
+  const buf = Buffer.from('FFFFE282AC61FFFF', 'hex')
+  // Slice uses begin/end, not length.
+  // Make sure we're truncated so that we can reason about slices.
+  const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+  // Uint16Array uses byte offset, then count of 16-bit words.
+  const u = new Uint16Array(ab, 2, 2)
+  assert.equal(td.decode(u), '€a')
 
   const td2 = new TD('utf8', {fatal: true, ignoreBOM: false})
   assert.equal(td2.decode(Buffer.from('EFBBBFE282AC', 'hex')), '€')
@@ -20,25 +31,28 @@ function test(TD) {
   assert.equal(td2.decode(Buffer.from('82', 'hex'), {stream: true}), '')
   assert.equal(td2.decode(Buffer.from('AC', 'hex'), {stream: true}), '€')
 
-  // This should throw, but we can't detect trailing invalid encoding in
-  // stream mode. See: https://github.com/hildjj/ctoaf-textdecoder/issues/4
-  // assert.throws(
-  //   () => td2.decode(Buffer.from('E1A0C0', 'hex'), {stream: true})
-  // )
+  assert.throws(
+    () => td2.decode(Buffer.from('E1A0C0', 'hex'), {stream: true})
+  )
+  assert.throws(() => td2.decode(Buffer.from('FF', 'hex')))
+  assert.throws(() => td2.decode(Buffer.from('AC', 'hex')))
+  assert.throws(() => td2.decode(Buffer.from('EF61', 'hex')))
+  assert.throws(() => td2.decode(Buffer.from('E282', 'hex')))
 
   const td3 = new TD()
   assert.equal(td3.decode(Buffer.from('EFBBBFE282AC', 'hex')), '€')
+  assert.equal(td3.decode(Buffer.from('61FF61', 'hex')), 'a\ufffda')
+  assert.equal(td3.decode(Buffer.from('61AC', 'hex')), 'a\ufffd')
+  assert.equal(td3.decode(Buffer.from('EF61', 'hex')), '\ufffda')
+  assert.equal(td3.decode(Buffer.from('E2E282AC', 'hex')), '\ufffd€')
+  assert.equal(td3.decode(Buffer.from('E282', 'hex')), '\ufffd')
+  assert.equal(td3.decode(ab), '\ufffd\ufffd€a\ufffd\ufffd')
 }
 
-// Test the selected version.  Uninteresting if we're using the native version.
+// Test the selected version.  Uninteresting if we're using the native
+// version, except to ensure we've created the same interface with the
+// polyfill.
 test(TxtD)
 
-if ((typeof TextDecoder !== 'undefined') &&
-    (typeof Symbol === 'function') &&
-    (typeof Symbol.for === 'function')) {
-  // Test the polyfill version explicitly
-  assert.equal(TxtD, TextDecoder)
-  const Polyfill = TxtD[Symbol.for('@cto.af/textdecoder/polyfill')]
-  assert(Polyfill)
-  test(Polyfill)
-}
+assert(Polyfill)
+test(Polyfill)


### PR DESCRIPTION
Fixes #4.  Split polyfill out into a separate file, which is only required if needed.  Make the polyfill actually implement utf8.  Match errors with more edge cases of built-in TextDecoder.